### PR TITLE
Amended the welcome message

### DIFF
--- a/src/start.js
+++ b/src/start.js
@@ -98,12 +98,14 @@ export const start = async () => {
 
     app.use('/graphql', bodyParser.json(), graphqlExpress({schema}))
 
-    app.use('/graphiql', graphiqlExpress({
+    const homePath = '/graphiql'
+
+    app.use(homePath, graphiqlExpress({
       endpointURL: '/graphql'
     }))
 
     app.listen(PORT, () => {
-      console.log(`Visit ${URL}:${PORT}`)
+      console.log(`Visit ${URL}:${PORT}${homePath}`)
     })
 
   } catch (e) {


### PR DESCRIPTION
The app now outputs "Visit localhost:3001/graphiql" instead of "Visit localhost:3001", which led to an empty page.